### PR TITLE
chore(parser): add stringer, improve error

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -12,7 +12,7 @@ import (
 type Node interface{}
 
 type Expression interface {
-	// Expression is a marker interface for all expression types
+	String() string
 }
 
 type ColumnExpression struct {
@@ -194,4 +194,38 @@ func (p *Parser) parseSelectTableName() (string, error) {
 	tableName := p.tokens[p.pos].Literal
 	p.pos++ // Move past the table name.
 	return tableName, nil
+}
+
+func (s *SelectStatement) String() string {
+	expressions := make([]string, len(s.Expressions))
+	for i, expr := range s.Expressions {
+		expressions[i] = expr.String()
+	}
+	tableName := "nil"
+	if s.Table != nil {
+		tableName = *s.Table
+	}
+	return fmt.Sprintf(
+		"SelectStatement(Expressions: [%s], Table: %s)",
+		strings.Join(expressions, ", "), tableName)
+}
+
+func (c *ColumnExpression) String() string {
+	return fmt.Sprintf("ColumnExpression(%s)", c.Name)
+}
+
+func (n *NumericLiteral) String() string {
+	return fmt.Sprintf("NumericLiteral(%f)", n.Value)
+}
+
+func (s *StringLiteral) String() string {
+	return fmt.Sprintf("StringLiteral('%s')", s.Value)
+}
+
+func (n *NullValue) String() string {
+	return "NullValue(NULL)"
+}
+
+func (b *BooleanLiteral) String() string {
+	return fmt.Sprintf("BooleanLiteral(%t)", b.Value)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -176,6 +177,74 @@ func TestParser(t *testing.T) {
 				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("Parser.Parse() error = %v, at position %d, wantErr %v", err, p.pos, tt.wantErr)
 				}
+			}
+		})
+	}
+}
+
+func TestNodeStringMethods(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     fmt.Stringer
+		expected string
+	}{
+		{
+			name: "SelectStatement with expressions",
+			node: &SelectStatement{
+				Expressions: []Expression{
+					&NumericLiteral{Value: 123},
+				},
+			},
+			expected: "SelectStatement(Expressions: [NumericLiteral(123.000000)], Table: nil)",
+		},
+		{
+			name: "SelectStatement with expressions with table",
+			node: &SelectStatement{
+				Expressions: []Expression{
+					&ColumnExpression{Name: "column1"},
+					&NumericLiteral{Value: 123},
+				},
+				Table: addr("table1"),
+			},
+			expected: "SelectStatement(Expressions: [ColumnExpression(column1), NumericLiteral(123.000000)], Table: table1)",
+		},
+		{
+			name:     "ColumnExpression",
+			node:     &ColumnExpression{Name: "column2"},
+			expected: "ColumnExpression(column2)",
+		},
+		{
+			name:     "NumericLiteral",
+			node:     &NumericLiteral{Value: 456.78},
+			expected: "NumericLiteral(456.780000)",
+		},
+		{
+			name:     "StringLiteral",
+			node:     &StringLiteral{Value: "test string"},
+			expected: "StringLiteral('test string')",
+		},
+		{
+			name:     "NullValue",
+			node:     &NullValue{},
+			expected: "NullValue(NULL)",
+		},
+		{
+			name:     "BooleanLiteral True",
+			node:     &BooleanLiteral{Value: true},
+			expected: "BooleanLiteral(true)",
+		},
+		{
+			name:     "BooleanLiteral False",
+			node:     &BooleanLiteral{Value: false},
+			expected: "BooleanLiteral(false)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.node.String()
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
for debug

fixes #47 

before:
```
--- FAIL: TestParser (0.00s)
    --- FAIL: TestParser/simple_select (0.00s)
        parser_test.go:131: Parser.Parse() = [0xc000014cc0], want &{Expressions:[0xc0000286b0] Table:0xc0000286c0 Where:<nil>}
```

Improved error like this:
```
--- FAIL: TestParser (0.00s)
    --- FAIL: TestParser/multiple_statements (0.00s)
        parser_test.go:170: Parser.Parse() = [SelectStatement(Expressions: [NumericLiteral(1.000000)], Table: nil) SelectStatement(Expressions: [NumericLiteral(3.000000)], Table: nil)], want [SelectStatement(Expressions: [NumericLiteral(1.000000)], Table: nil) SelectStatement(Expressions: [NumericLiteral(2.000000)], Table: nil)]
```